### PR TITLE
fix(backend): typeshare config file not being read everytime

### DIFF
--- a/backend/generate-typeshare.sh
+++ b/backend/generate-typeshare.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 SCRIPT_DIR=$(dirname -- "$0")
-typeshare --lang typescript --output-file $SCRIPT_DIR/../frontend/src/@types/api.ts $SCRIPT_DIR
+typeshare --lang typescript --output-file $SCRIPT_DIR/../frontend/src/@types/api.ts --config-file $SCRIPT_DIR/typeshare.toml $SCRIPT_DIR
 
 pushd $SCRIPT_DIR/../frontend
 npm run format:typeshare


### PR DESCRIPTION
Did not work if the script was executed from a parent directory.