### PR TITLE
refactor(backend): add a third state to nomination validation

### DIFF
--- a/backend/entity/src/nomination.rs
+++ b/backend/entity/src/nomination.rs
@@ -10,7 +10,7 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub username: String,
     pub display_name: String,
-    pub valid: bool,
+    pub valid: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -2,6 +2,7 @@ pub use sea_orm_migration::prelude::*;
 
 mod m20220101_000001_create_table;
 mod m20230917_143144_nomination_log;
+mod m20231001_091623_nomination_valid_null;
 
 pub struct Migrator;
 
@@ -11,6 +12,7 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(m20220101_000001_create_table::Migration),
             Box::new(m20230917_143144_nomination_log::Migration),
+            Box::new(m20231001_091623_nomination_valid_null::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20231001_091623_nomination_valid_null.rs
+++ b/backend/migration/src/m20231001_091623_nomination_valid_null.rs
@@ -1,0 +1,35 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Nomination::Table)
+                    .modify_column(ColumnDef::new(Nomination::Valid).boolean().null())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Nomination::Table)
+                    .modify_column(ColumnDef::new(Nomination::Valid).boolean().not_null())
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum Nomination {
+    Table,
+    Valid,
+}


### PR DESCRIPTION
We need to distinguish between a nomination that has been marked as invalid and a nomination that has not been validated yet. If a nomination has a null valid state, it has not been validated manually yet.

Related to #88