### PR TITLE
refactor(backend): correctly sort unvalidated nominations

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1501,6 +1501,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "sha2 0.10.7",
+ "slice-group-by",
  "tokio",
  "tower",
  "tower-http",
@@ -2644,6 +2645,12 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -28,6 +28,7 @@ reqwest = { version = "0.11.18", features = ["json"] }
 sea-orm.workspace = true
 serde = { version = "1.0.164", features = ["derive"] }
 sha2 = "0.10.7"
+slice-group-by = "0.3.1"
 tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread"] }
 tower = "0.4.13"
 tower-http = { version = "0.4.3", features = ["add-extension", "fs", "trace"] }

--- a/backend/src/dtos.rs
+++ b/backend/src/dtos.rs
@@ -258,7 +258,7 @@ pub struct CastVoteDto {
 #[serde(rename_all = "camelCase")]
 pub struct ElectionWithUnverifedNominationsDto {
     pub id: i32,
-    pub degree: DegreeDto,
+    pub degree: Option<DegreeDto>,
     pub curricular_year: Option<i32>,
     pub round: i32,
     pub nominations: Vec<NominationDto>,
@@ -274,10 +274,10 @@ pub struct NominationDto {
 }
 
 impl NominationDto {
-    pub fn from_entity(entity: nomination::Model) -> Self {
+    pub fn from_entity(entity: &nomination::Model) -> Self {
         NominationDto {
-            username: entity.username,
-            display_name: entity.display_name,
+            username: entity.username.clone(),
+            display_name: entity.display_name.clone(),
             valid: entity.valid,
         }
     }


### PR DESCRIPTION
HashMap order is not stable, so that does not guarantee the order from the SQL query is preserved.