### PR TITLE
refactor(backend): use bennu's person find endpoint instead

### DIFF
--- a/backend/src/routes/search_user.rs
+++ b/backend/src/routes/search_user.rs
@@ -40,7 +40,7 @@ pub async fn search_user(
 
     Ok(Json(
         results
-            .items
+            .users
             .into_iter()
             .map(|result| sign_person_search_result(election.id, result, signing_key))
             .collect(),

--- a/backend/src/services/fenix.rs
+++ b/backend/src/services/fenix.rs
@@ -153,17 +153,19 @@ impl FenixService {
         &self,
         oauth_token: &str,
         query: &str,
-        degree_id: &str,
+        _degree_id: &str,
     ) -> reqwest::Result<PersonSearchResponse> {
         let client = reqwest::Client::new();
 
         client
-            .get(format!(
-                "{}{}/person/search",
-                self.base_url, TECNICO_API_PREFIX
-            ))
-            .query(&[("name", query), ("role", "STUDENT"), ("degree", degree_id)])
+            .post(format!("{}/api/bennu-core/users/find", self.base_url,))
+            .query(&[
+                ("query", query),
+                ("includeInactive", "false"),
+                ("maxHits", "20"),
+            ])
             .header("Authorization", format!("Bearer {}", oauth_token))
+            .header("X-Requested-With", "XMLHttpRequest")
             .send()
             .await?
             .json()
@@ -299,8 +301,7 @@ struct ExecutionYear {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PersonSearchResponse {
-    pub total_items: i32,
-    pub items: Vec<PersonSearchResult>,
+    pub users: Vec<PersonSearchResult>,
 }
 
 #[derive(Deserialize)]

--- a/frontend/src/locales/en-GB/translation.json
+++ b/frontend/src/locales/en-GB/translation.json
@@ -159,6 +159,6 @@
     "label": "Student to Nominate",
     "loading": "Loading results...",
     "no-results": "No results have been found",
-    "placeholder": "Type a student's name"
+    "placeholder": "Type a student's name or IST-ID"
   }
 }

--- a/frontend/src/locales/pt-PT/translation.json
+++ b/frontend/src/locales/pt-PT/translation.json
@@ -154,6 +154,6 @@
     "label": "Estudante a Nomear",
     "loading": "A carregar resultados...",
     "no-results": "Não foram encontrados resultados",
-    "placeholder": "Procurar pelo nome do estudante"
+    "placeholder": "Procurar pelo nome ou IST-ID do estudante"
   }
 }


### PR DESCRIPTION
The latest version of tecnico-api has not been deployed yet, which prevents us to use its person find endpoint.

Therefore, we have to use bennu's endpoint, which searches everyone instead of only students of a certain degree, but on the other hand allows users to search by IST-ID.

This commit should be reverted once tecnico-api is deployed.

For now, this means #85 can be postponed to a later release.