### PR TITLE
refactor(frontend): move logged in detection logic to loader

### DIFF
--- a/frontend/src/routes/admin/admins.tsx
+++ b/frontend/src/routes/admin/admins.tsx
@@ -69,7 +69,7 @@ function Admins() {
                 <FenixAvatar username={admin.username} size={128} />
                 <Typography variant='h6' component='span' sx={{ my: 2 }}>
                   {admin.username}
-                  {admin.username === auth?.user.username && (
+                  {admin.username === auth.user.username && (
                     <Chip
                       sx={{ ml: 1 }}
                       color='primary'
@@ -97,7 +97,7 @@ function Admins() {
                   component={Link}
                   to={`remove/${encodeURIComponent(admin.username)}`}
                   color='error'
-                  disabled={admins.length < 2 || admin.username === auth?.user.username}
+                  disabled={admins.length < 2 || admin.username === auth.user.username}
                 >
                   {t('admin.subpages.admin-management.remove-button')}
                 </Button>

--- a/frontend/src/routes/root.tsx
+++ b/frontend/src/routes/root.tsx
@@ -17,9 +17,11 @@ export async function loader() {
 
   if (!auth) {
     const { baseUrl, clientId, redirectUrl } = appConfig.fenix;
-    return redirect(`${baseUrl}/oauth/userdialog?client_id=${encodeURIComponent(
-      clientId
-    )}&redirect_uri=${encodeURIComponent(redirectUrl)}`);
+    return redirect(
+      `${baseUrl}/oauth/userdialog?client_id=${encodeURIComponent(
+        clientId
+      )}&redirect_uri=${encodeURIComponent(redirectUrl)}`
+    );
   }
 
   return { appConfig, auth };

--- a/frontend/src/routes/root.tsx
+++ b/frontend/src/routes/root.tsx
@@ -1,19 +1,26 @@
 import { Box, Button, Container, Typography } from '@mui/material';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Outlet, useLoaderData, useNavigate } from 'react-router-dom';
+import { Outlet, redirect, useLoaderData, useNavigate } from 'react-router-dom';
 import { AppConfigDto, AuthDto } from '../@types/api';
 import { getAppConfig, getWhoAmI, setupFirstAdmin } from '../api';
 import FenixAvatar from '../components/fenix/FenixAvatar';
 
 export interface RootData {
   appConfig: AppConfigDto;
-  auth?: AuthDto;
+  auth: AuthDto;
 }
 
-export async function loader(): Promise<RootData> {
+export async function loader() {
   const appConfig = await getAppConfig();
   const auth = await getWhoAmI().catch(() => undefined);
+
+  if (!auth) {
+    const { baseUrl, clientId, redirectUrl } = appConfig.fenix;
+    return redirect(`${baseUrl}/oauth/userdialog?client_id=${encodeURIComponent(
+      clientId
+    )}&redirect_uri=${encodeURIComponent(redirectUrl)}`);
+  }
 
   return { appConfig, auth };
 }
@@ -23,38 +30,28 @@ function Root() {
   const { appConfig, auth } = useLoaderData() as RootData;
   const { t } = useTranslation();
 
-  // redirect logged-out users to SSO
-  useEffect(() => {
-    if (!auth) {
-      const { baseUrl, clientId, redirectUrl } = appConfig.fenix;
-      window.location.href = `${baseUrl}/oauth/userdialog?client_id=${encodeURIComponent(
-        clientId
-      )}&redirect_uri=${encodeURIComponent(redirectUrl)}`;
-    }
-  }, [auth, appConfig.fenix]);
-
   // create first admin user
   useEffect(() => {
-    if (auth && !appConfig.isSetup) {
+    if (!appConfig.isSetup) {
       setupFirstAdmin()
         .then(() => navigate('/'))
         .catch(console.error); // ignore errors
     }
-  }, [auth, appConfig.isSetup, navigate]);
+  }, [appConfig.isSetup, navigate]);
 
   return (
     <Container>
       <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', my: 4 }}>
-        {auth?.isAdmin && (
+        {auth.isAdmin && (
           <>
             <Button>{t('admin.page.title')}</Button>
             <Box sx={{ flexGrow: 1 }} />
           </>
         )}
         <Typography sx={{ mr: 2 }} variant='h6' component='span'>
-          {auth?.user.displayName}
+          {auth.user.displayName}
         </Typography>
-        <FenixAvatar username={auth?.user.username || ''} size={40} />
+        <FenixAvatar username={auth.user.username || ''} size={40} />
       </Box>
       <Outlet />
     </Container>


### PR DESCRIPTION
This prevents issues with the pages loading when a user is not logged in, showing error pages before the user is redirected.