### PR TITLE
chore: fix nix module error when coercing port to string

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -13,7 +13,7 @@ in {
 
       fqdn = mkOption {
         type = types.str;
-        default = "http://localhost:${cfg.port}";
+        default = "http://localhost:${toString cfg.port}";
         defaultText = literalExpression
           ''"http://localhost:''${services.ist-delegate-election.port}"'';
         description = lib.mdDoc ''


### PR DESCRIPTION
Fixes #156